### PR TITLE
Fix destination backup check

### DIFF
--- a/btrfs-sync
+++ b/btrfs-sync
@@ -232,7 +232,7 @@ sync_snapshot() {
   local SRC="$1"
   [[ -d "$SRC" ]] || return
 
-  exists_at_dst "$SRC" && { echov "* Skip existing '$SRC'"; return 0; }
+  exists_at_dst "$SRC" || { echov "* Skip existing '$SRC'"; return 0; }
 
   choose_seed "$SRC"  # sets SEED
 


### PR DESCRIPTION
The destination snapshot comparison does not work on my setup.
Actually exists_at_dst returns 1 when the snapshot already exists remotely
On the other side, "function_call && exit" only exit if the function_call return code is 0, i.e fine 