### PR TITLE
Add a flag to force non-incremental mode

### DIFF
--- a/btrfs-sync
+++ b/btrfs-sync
@@ -9,6 +9,7 @@
 #
 #  -k|--keep NUM     keep only last <NUM> sync'ed snapshots
 #  -d|--delete       delete snapshots in <dst> that don't exist in <src>
+#  -f|--full         disable incremental backup
 #  -z|--xz           use xz     compression. Saves bandwidth, but uses one CPU
 #  -Z|--pbzip2       use pbzip2 compression. Saves bandwidth, but uses all CPUs
 #  -q|--quiet        don't display progress
@@ -41,6 +42,7 @@ print_usage() {
 
   -k|--keep NUM     keep only last <NUM> sync'ed snapshots
   -d|--delete       delete snapshots in <dst> that don't exist in <src>
+  -f|--full         disable incremental backup
   -z|--xz           use xz     compression. Saves bandwidth, but uses one CPU
   -Z|--pbzip2       use pbzip2 compression. Saves bandwidth, but uses all CPUs
   -p|--port         SSH port. Default 22
@@ -76,7 +78,7 @@ PORT=22
 ZIP=cat PIZ=cat
 SILENT=">/dev/null"
 
-OPTS=$( getopt -o hqzZk:p:dv -l quiet -l help -l xz -l pbzip2 -l keep: -l port: -l delete -l verbose -- "$@" 2>/dev/null )
+OPTS=$( getopt -o hqzZk:p:fdv -l quiet -l help -l xz -l pbzip2 -l keep: -l port: -l full -l delete -l verbose -- "$@" 2>/dev/null )
 [[ $? -ne 0 ]] && { echo "error parsing arguments"; exit 1; }
 eval set -- "$OPTS"
 
@@ -84,6 +86,7 @@ while true; do
   case "$1" in
     -h|--help   ) print_usage; exit  0 ;;
     -q|--quiet  ) QUIET=1    ; shift 1 ;;
+    -f|--full   ) FULL=1     ; shift 1 ;;
     -d|--delete ) DELETE=1   ; shift 1 ;;
     -k|--keep   ) KEEP=$2    ; shift 2 ;;
     -p|--port   ) PORT=$2    ; shift 2 ;;
@@ -235,7 +238,7 @@ sync_snapshot() {
 
   exists_at_dst "$SRC" && { echov "* Skip existing '$SRC'"; return 0; }
 
-  choose_seed "$SRC"  # sets SEED
+  [[ "$FULL" == "1" ]] && SEED="" || choose_seed "$SRC"  # sets SEED
 
   # incremental sync argument
   [[ "$SEED" != "" ]] && {
@@ -312,3 +315,4 @@ exit 0
 # You should have received a copy of the GNU General Public License
 # along with this script; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA 02111-1307 USA


### PR DESCRIPTION
I used this great tool to backup my remote server, with several subvolumes on the same filesystem (notably, home and rootfs). I believe this use case (and in general, the need for saving totally unrelated snapshots to the same target) is not rare, hence this PR.